### PR TITLE
fixed another bug with table layout

### DIFF
--- a/output/app.js
+++ b/output/app.js
@@ -9,8 +9,7 @@ var testData = {
     },
     data: [
         {
-            'mentions_17283728' : 131,
-            'mentions_17283729' : 94
+            'mentions_17283729' : 131
         },
         {
             'mentions_17283728' : 130,

--- a/output/index.html
+++ b/output/index.html
@@ -31,8 +31,8 @@
         <tbody>
         <tr ng-repeat="data in tableController.data">
             <th>{{tableController.categories[$index]  | date:'medium'}}</th>
-            <td ng-repeat="(key, value) in data">
-                {{value}}
+            <td ng-repeat="value in tableController.values">
+                {{data[value]}}
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
Bit of an obscure one but basically if you have sparse data, the order of the output values can get messed up, and that's what this PR fixes. Unlikely to happen but can be caused by adding extra sources after an experiment has started.

Also wondering if we should move core slabs into the slabs organisation?
